### PR TITLE
Don't filter categories in AJAX requests

### DIFF
--- a/restricted-authors.php
+++ b/restricted-authors.php
@@ -217,7 +217,10 @@ final class Restricted_Authors {
 		}
 		$restricted_categories = get_user_meta( $current_user->ID, '_restricted_authors_restricted_category', true );
 
-		$args['include'] = $restricted_categories;
+		// Don't filter terms if there aren't any restricted_categories or if we are in a XHR request such as wp-admin/admin-ajax.php
+		if ( !empty( $restricted_categories ) && !wp_doing_ajax() ) {
+			$args['include'] = $restricted_categories;
+		}
 
 		return $args;
 	}


### PR DESCRIPTION
Avoid filtering terms if there aren't any restricted_categories or if we are in a XHR request such as wp-admin/admin-ajax.php

My site is getting some of its contents through a XHR request to wp-admin/admin-ajax.php and your plugin keeps changing the terms query arguments. 

I am using "The Gem" theme with WP Bakery plugin. Besides, in some pages I have added blocks such as "Post Grid" to load content from some categories. This block loads its contents through a XHR request to wp-admin/admin-ajax.php. However, your plugin always filters requested terms with the get_terms_args filter.

How about avoiding filtering requested terms when the user do not have any restricted categories or when the request has been received throught AJAX?